### PR TITLE
Copy url to clipboard

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -20,6 +20,7 @@ const fs = require('fs-promise')
 const auth = require('basic-auth')
 const stream = require('send')
 const updateNotifier = require('update-notifier')
+const {copy} = require('copy-paste')
 
 // Ours
 const pkg = require('../package')
@@ -330,10 +331,20 @@ const handler = async (req, res) => {
   }
 }
 
+const copyToClipboard = async text => {
+  try {
+    await copy(text)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
 const server = flags.unzipped ? micro(handler) : micro(compress(handler))
 
 server.listen(flags.port, async () => {
   const details = server.address()
+  const url = `http://localhost:${details.port}`
 
   process.on('SIGINT', () => {
     server.close()
@@ -346,6 +357,13 @@ server.listen(flags.port, async () => {
   }
 
   if (!process.env.NOW) {
-    console.log(`Running on http://localhost:${details.port}`)
+    let message = `Running on ${url}`
+    const copied = await copyToClipboard(url)
+
+    if (copied) {
+      message = `${message} [copied to clipboard]`
+    }
+
+    console.log(message)
   }
 })

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "args": "^2.2.1",
     "basic-auth": "^1.1.0",
     "chalk": "^1.1.3",
+    "copy-paste": "^1.3.0",
     "filesize": "^3.3.0",
     "fs-promise": "^1.0.0",
     "handlebars": "^4.0.6",


### PR DESCRIPTION
This is an idea I had, let me know what you think.

I love that `now` copies the address to my clipboard, and as I use `serve` a lot to quickly share a folder, I would love to have that feature here. Also, with the [random port feature](https://github.com/zeit/serve/commit/d177add755a0500c465fdfc87dcbde6d58a3cb01) in the last version, I find this way easier to work with (cause before I would be always visiting `:3000`)

![serve](https://cloud.githubusercontent.com/assets/4324982/21904049/3fb5365c-d8d0-11e6-9c96-3201898106bd.png)
