### PR TITLE
Improve CSS font stack

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -3,7 +3,7 @@ body {
   margin: 0;
   padding: 30px;
   -webkit-font-smoothing: antialiased;
-  font-family: Menlo;
+  font-family: Menlo, Consolas, monospace;
 }
 
 main {


### PR DESCRIPTION
I noticed while playing around with `serve` that the directory contents list was rendered in monospaced font on macOS but sans serif on Windows. This change adds fallback fonts such that the list will always be rendered in monospaced font.