### PR TITLE
Display IP address instead of localhost

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -1,5 +1,6 @@
 // Packages
 const {copy} = require('copy-paste')
+const ip = require('ip')
 const pathType = require('path-type')
 const {red} = require('chalk')
 
@@ -14,7 +15,8 @@ const copyToClipboard = async text => {
 
 module.exports = async (server, current) => {
   const details = server.address()
-  const url = `http://localhost:${details.port}`
+  const ipAddress = ip.address()
+  const url = `http://${ipAddress}:${details.port}`
 
   process.on('SIGINT', () => {
     server.close()

--- a/lib/render.js
+++ b/lib/render.js
@@ -5,6 +5,7 @@ const path = require('path')
 const pathType = require('path-type')
 const filesize = require('filesize')
 const fs = require('fs-promise')
+const ip = require('ip')
 
 // Ours
 const prepareView = require('./view')
@@ -93,6 +94,7 @@ module.exports = async (port, current, dir, ignoredFiles) => {
   }
 
   const details = {
+    address: ip.address(),
     port,
     files,
     assetDir: process.env.ASSET_DIR,

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "fs-promise": "^1.0.0",
     "get-port": "^2.1.0",
     "handlebars": "^4.0.6",
+    "ip": "^1.1.4",
     "istextorbinary": "^2.1.0",
     "micro": "^6.1.0",
     "micro-compress": "^1.0.0",

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -31,7 +31,7 @@
     </main>
 
     <aside>
-      <p>Node {{nodeVersion}} and <a href="https://github.com/zeit/serve" target="_blank" rel="noopener noreferrer">serve</a> running @ localhost:{{port}}</p>
+      <p>Node {{nodeVersion}} and <a href="https://github.com/zeit/serve" target="_blank" rel="noopener noreferrer">serve</a> running @ {{address}}:{{port}}</p>
     </aside>
   </body>
 </html>


### PR DESCRIPTION
Display network IP address (rather than localhost) both on command line and in rendered view to make sharing links across machines more seamless.