### PR TITLE
Fix asset dir check on Windows

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -33,10 +33,11 @@ module.exports = async (req, res, flags, current, ignoredFiles) => {
   }
 
   const {pathname} = parse(req.url)
+  const assetDir = path.normalize(process.env.ASSET_DIR)
   let related = path.parse(path.join(current, pathname))
 
-  if (related.dir.indexOf(process.env.ASSET_DIR) > -1) {
-    const relative = path.relative(process.env.ASSET_DIR, pathname)
+  if (related.dir.indexOf(assetDir) > -1) {
+    const relative = path.relative(assetDir, pathname)
     related = path.parse(path.join(__dirname, '/../assets', relative))
   }
 


### PR DESCRIPTION
The asset dir check always fails on Windows unless you normalize the delimiters. This bug resulted in the stylesheet 404ing when running `serve` from a Windows machine.