### PR TITLE
enable listen on process.env.PORT

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,8 +11,10 @@ const getPort = require('get-port')
 const listening = require('./listening')
 const serverHandler = require('./server')
 
+const envPort = process.env.PORT
+
 args
-  .option('port', 'Port to listen on', process.env.PORT)
+  .option('port', 'Port to listen on', envPort)
   .option('cache', 'How long static files should be cached in the browser (seconds)', 3600)
   .option('single', 'Serve single page apps with only one index.html')
   .option('unzipped', 'Disable GZIP compression')
@@ -47,5 +49,5 @@ const handler = async (req, res) => {
 const server = flags.unzipped ? micro(handler) : micro(compress(handler))
 
 getPort().then(randomPort => {
-  server.listen(flags.port || randomPort, async () => await listening(server, current))
+  server.listen(flags.port || envPort || randomPort, async () => await listening(server, current))
 })


### PR DESCRIPTION
Currently lists the `process.env.PORT` as the default port but it was never actually passed to the server.

Order of selection is now `flags.port > process.env.PORT > randomPort` .