### PR TITLE
Prevent throw during `--single` mode

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -43,6 +43,8 @@ module.exports = async (req, res, flags, current, ignoredFiles) => {
 
   related = decodeURIComponent(path.format(related))
 
+  const relatedExists = fs.existsSync(related)
+
   let notFoundResponse = 'Not Found'
 
   try {
@@ -50,12 +52,12 @@ module.exports = async (req, res, flags, current, ignoredFiles) => {
     notFoundResponse = await fs.readFile(custom404Path, 'utf-8')
   } catch (err) {}
 
-  if (!fs.existsSync(related) && flags.single === undefined) {
+  if (!relatedExists && flags.single === undefined) {
     return micro.send(res, 404, notFoundResponse)
   }
 
   // Check if file or directory path
-  if (await pathType.dir(related)) {
+  if (relatedExists && await pathType.dir(related)) {
     let indexPath = path.join(related, '/index.html')
 
     res.setHeader('Content-Type', mime.contentType(path.extname(indexPath)))


### PR DESCRIPTION
The `path-type` module does not wrap its `dir()` functions with any kind of `catch` handler, so it requires that all strings must be pre-verified. 

During `--single` mode, any nested route (eg, `/blog/article2`) is eventually passed along as `/Users/.../dist/blog/article2`, which does not exist (assuming `dist` is the base directory).

And so, because non-existent paths are sent to `pathType.dir()`, a `Error: ENOENT` is thrown, which causes the 502 error that I & others were experiencing. 

Closes #73 