### PR TITLE
Fix directory name render issue when running on Windows

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -55,7 +55,7 @@ module.exports = async (port, current, dir, ignoredFiles) => {
   }
 
   const directory = path.join(path.basename(current), subPath, '/')
-  const pathParts = directory.split('/')
+  const pathParts = directory.split(path.sep)
 
   if (dir.indexOf(current + '/') > -1) {
     const directoryPath = [...pathParts]


### PR DESCRIPTION
Current logic surrounding generating the rendered directory name uses hardcoded directory separator; this resulted in the directory name missing from rendered output when running `serve` on Windows. This change updates the render code to instead use OS-specific separator.