### PR TITLE
Correct pseudo-elements syntax

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -30,7 +30,7 @@ h1 a {
   border-bottom: 1px dashed transparent;
 }
 
-h1 a:after {
+h1 a::after {
   content: '/';
 }
 
@@ -72,7 +72,7 @@ ul a {
   text-overflow: ellipsis;
 }
 
-ul a:before {
+ul a::before {
   content: '\f016';
   font-family: FontAwesome;
   display: inline-block;
@@ -88,7 +88,7 @@ ul a[class=''] + i {
   display: none;
 }
 
-ul a[class='']:before {
+ul a[class='']::before {
   content: '\f114';
   font-size: 14px;
 }


### PR DESCRIPTION
Makes no difference as all browser support the old syntax for backward compatibility, but I prefer the correct syntax.

```
The double colon replaced the single-colon notation for pseudo-elements in CSS3. This was an attempt from W3C to distinguish between pseudo-classes and pseudo-elements.

The single-colon syntax was used for both pseudo-classes and pseudo-elements in CSS2 and CSS1.

For backward compatibility, the single-colon syntax is acceptable for CSS2 and CSS1 pseudo-elements.
```