### PR TITLE
Fixes the cache option's maxAge header

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -72,7 +72,7 @@ module.exports = async (req, res, flags, current, ignoredFiles) => {
   const streamOptions = {}
 
   if (flags.cache) {
-    streamOptions.maxAge = flags.cache
+    streamOptions.maxAge = flags.cache * 1000
   }
 
   // Check if directory


### PR DESCRIPTION
Hi there,

The `--cache` option incorrectly handles the time passed as argument: the `send` package (called `stream` in the code) expects the parameter `maxAge` to be a time in milliseconds whereas `serve` expects the command line argument in seconds.

In the current version of the module, the conversion from seconds to milliseconds isn't done. This PR simply multiplies the entry value by 1000.

Clément