### PR TITLE
Remove the bullet characters

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -43,8 +43,8 @@ module.exports = async (server, current, inUse) => {
 
     const localURL = `http://localhost:${details.port}`
 
-    message += `• ${chalk.bold('Local:           ')} ${localURL}\n`
-    message += `• ${chalk.bold('On Your Network: ')} ${url}\n\n`
+    message += `- ${chalk.bold('Local:           ')} ${localURL}\n`
+    message += `- ${chalk.bold('On Your Network: ')} ${url}\n\n`
 
     if (isTTY) {
       const copied = await copyToClipboard(url)


### PR DESCRIPTION
 On Windows, they're not printed to the console and produce an unexpected beep sound instead.