### PR TITLE
Add title attributes to file links

### DIFF
--- a/lib/render.js
+++ b/lib/render.js
@@ -47,6 +47,8 @@ module.exports = async (port, current, dir, ignoredFiles) => {
       details.size = filesize(fileStats.size, {round: 0})
     }
 
+    details.title = details.base
+
     if (ignoredFiles.indexOf(details.base) > -1) {
       delete files[index]
     } else {
@@ -63,7 +65,8 @@ module.exports = async (port, current, dir, ignoredFiles) => {
 
     files.unshift({
       base: '..',
-      relative: path.join(...directoryPath, '..')
+      relative: path.join(...directoryPath, '..'),
+      title: path.join(...pathParts.slice(0, -2), '/')
     })
   }
 

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -23,7 +23,7 @@
       <ul>
         {{#each files}}
           <li>
-            <a href="/{{relative}}" class="{{ext}}">{{base}}</a>
+            <a href="/{{relative}}" title="{{title}}" class="{{ext}}">{{base}}</a>
             <i>{{size}}</i>
           </li>
         {{/each}}


### PR DESCRIPTION
This change adds `title` attributes to the file links such that when the file name is elided, the user can hover over the link to see the full file name.

![add-link-titles](https://cloud.githubusercontent.com/assets/1706502/22857715/0143e55a-f070-11e6-92b5-8943f4ab2390.gif)

I've added the `title` property to the file objects rather than simply re-using the `base` property because I wanted to be able to add more verbose titles to the parent directory links.