### PR TITLE
Fix a trailing slash with query strings

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 // Native
 const path = require('path')
-const {parse} = require('url')
+const {parse, format} = require('url')
 
 // Packages
 const micro = require('micro')
@@ -79,8 +79,10 @@ module.exports = async (req, res, flags, current, ignoredFiles) => {
   if (relatedExists && await pathType.dir(related)) {
     // Normalize path to trailing slash
     // Otherwise problems like #70 will occur
-    if (req.url.substr(-1) !== '/') {
-      const newPath = req.url + '/'
+    const url = parse(req.url)
+    if (url.pathname.substr(-1) !== '/') {
+      url.pathname += '/'
+      const newPath = format(url)
 
       res.writeHead(302, {
         Location: newPath


### PR DESCRIPTION
I've fixed unexpected normalizing trailing slash.

- before: `/foo?bar=baz` -> `/foo?bar=baz/`
- after: `/foo?bar=baz` -> `/foo/?bar=baz`

Please review.