### PR TITLE
Add command example in doc to set env variables

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ serve help
 
 If you set the `--auth` flag, the package will look for a username and password in the `SERVE_USER` and `SERVE_PASSWORD` environment variables.
 
+Or you can quickly set the enviroment variables with this command in your terminal:
+
+```bash
+SERVE_USER=123 SERVE_PASSWORD=123 serve --auth
+```
+
 ## Contributing
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device


### PR DESCRIPTION
Sometimes I want to launch serve quickly with some user and password and there was no copy-paste example in the documentation and without having to write in a file the environment variables.

