### PR TITLE
Add a programmatic API (fixes #86)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -15,7 +15,14 @@ const optionsToArgs = options => {
 
 module.exports = (options = {}, directory = process.cwd()) => {
   const scriptPath = path.join(__dirname, '..', 'bin', 'serve.js')
-  spawn('node',
+
+  const cli = spawn('node',
     [scriptPath, ...optionsToArgs(options), directory],
     {stdio: 'inherit'})
+
+  return {
+    stop() {
+      cli.kill()
+    }
+  }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -8,11 +8,17 @@ const dargs = require('dargs')
 module.exports = (options = {}, directory = process.cwd()) => {
   const scriptPath = path.join(__dirname, '..', 'bin', 'serve.js')
   const aliases = {cors: 'o'}
+
   options._ = [directory]  // Let dargs handle the directory argument
 
-  const cli = spawn('node',
-    [scriptPath, ...dargs(options, {aliases})],
-    {stdio: 'inherit'})
+  const args = [
+    scriptPath,
+    ...dargs(options, {aliases})
+  ]
+
+  const cli = spawn('node', args, {
+    stdio: 'inherit'
+  })
 
   return {
     stop() {

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,22 +2,16 @@
 const {spawn} = require('child_process')
 const path = require('path')
 
-// { port: 1337 } => ['--port', '1337']
-const optionsToArgs = options => {
-  const args = []
-  for (const prop in options) {
-    if (Object.prototype.hasOwnProperty.call(options, prop)) {
-      args.push(`--${prop}`, options[prop])
-    }
-  }
-  return args
-}
+// Packages
+const dargs = require('dargs')
 
 module.exports = (options = {}, directory = process.cwd()) => {
   const scriptPath = path.join(__dirname, '..', 'bin', 'serve.js')
+  const aliases = {cors: 'o'}
+  options._ = [directory]  // Let dargs handle the directory argument
 
   const cli = spawn('node',
-    [scriptPath, ...optionsToArgs(options), directory],
+    [scriptPath, ...dargs(options, {aliases})],
     {stdio: 'inherit'})
 
   return {

--- a/lib/api.js
+++ b/lib/api.js
@@ -11,6 +11,12 @@ module.exports = (options = {}, directory = process.cwd()) => {
 
   options._ = [directory]  // Let dargs handle the directory argument
 
+  // The CLI only understands comma-separated values for ignored files
+  // So we join the string array with commas
+  if (options.ignore) {
+    options.ignore = options.ignore.join(',')
+  }
+
   const args = [
     scriptPath,
     ...dargs(options, {aliases})

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,21 @@
+// Native
+const {spawn} = require('child_process')
+const path = require('path')
+
+// { port: 1337 } => ['--port', '1337']
+const optionsToArgs = options => {
+  const args = []
+  for (const prop in options) {
+    if (Object.prototype.hasOwnProperty.call(options, prop)) {
+      args.push(`--${prop}`, options[prop])
+    }
+  }
+  return args
+}
+
+module.exports = (options = {}, directory = process.cwd()) => {
+  const scriptPath = path.join(__dirname, '..', 'bin', 'serve.js')
+  spawn('node',
+    [scriptPath, ...optionsToArgs(options), directory],
+    {stdio: 'inherit'})
+}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "boxen": "1.0.0",
     "chalk": "1.1.3",
     "copy-paste": "1.3.0",
-    "dargs": "^5.1.0",
+    "dargs": "5.1.0",
     "detect-port": "1.1.0",
     "filesize": "3.5.4",
     "fs-promise": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "boxen": "1.0.0",
     "chalk": "1.1.3",
     "copy-paste": "1.3.0",
+    "dargs": "^5.1.0",
     "detect-port": "1.1.0",
     "filesize": "3.5.4",
     "fs-promise": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "views"
   ],
   "repository": "zeit/serve",
+  "main": "./lib/api.js",
   "bin": {
     "serve": "./bin/serve.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,62 @@ serve help
 
 If you set the `--auth` flag, the package will look for a username and password in the `SERVE_USER` and `SERVE_PASSWORD` environment variables.
 
+## API
+
+Install it (needs at least Node LTS):
+
+```bash
+npm install serve
+```
+
+You can now use it in your code:
+
+```js
+const serve = require('serve')
+
+const options = {
+  port: 1337,
+  cache: 0
+}
+
+const server = serve(options)
+
+// ...
+
+server.stop()
+
+```
+
+### Options
+
+#### `port: number`
+
+Port to listen on
+
+#### `cache: number`
+
+Time in milliseconds for caching files in the browser
+
+#### `single: boolean`
+
+Serve single page apps with only one `index.html`
+
+#### `unzipped: boolean`
+
+Disable GZIP compression
+
+#### `ignore: string[]`
+
+Files and directories to ignore
+
+#### `auth: boolean`
+
+Serve behind basic auth
+
+#### `cors: boolean`
+
+Setup * CORS headers to allow requests from any origin
+
 ## Contributing
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device


### PR DESCRIPTION
This is a prototype of `api.js` as discussed in #86. Here's what I think it should do:

- [x] Export a function that takes `options` and `directory` as arguments
- [x] Start a server based on those
- [x] Print the server info nicely, with colours and stuff (tested on Linux)
- [x] Take `stdin`, such as <kbd>^C</kbd> and behave accordingly
- [x] Return something to the caller (what?)
- [x] Write docs