### PR TITLE
Promisify copy

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -4,11 +4,13 @@ const ip = require('ip')
 const pathType = require('path-type')
 const chalk = require('chalk')
 const boxen = require('boxen')
-const {coroutine} = require('bluebird')
+const {coroutine, promisify} = require('bluebird')
+
+const copyAsync = promisify(copy)
 
 const copyToClipboard = coroutine(function * (text) {
   try {
-    yield copy(text)
+    yield copyAsync(text)
     return true
   } catch (err) {
     return false


### PR DESCRIPTION
`copy` needs to be promisified to expose errors from stderr within `copyToClipboard` (once xavi-/node-copy-paste#53 is merged this will be necessary to expose the error raised when the command required to copy to clipboard is missing).