### PR TITLE
Alias boolean cli flags in minimist config

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -42,6 +42,13 @@ args
 
 const flags = args.parse(process.argv, {
   minimist: {
+    alias: {
+      a: 'auth',
+      C: 'cors',
+      S: 'silent',
+      s: 'single',
+      u: 'unzipped'
+    },
     boolean: [
       'a', 'auth',
       'C', 'cors',


### PR DESCRIPTION
Looks like `minimist` defaults boolean flags to `false` which in turn messes with alias reconciliation in `args`. Simplest way to deal with this right now is to add `minimist` configuration for boolean flag aliases.

Closes #128 