### PR TITLE
solve icons with svgs in css. Abandon font-awesome

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -72,12 +72,12 @@ ul a {
   text-overflow: ellipsis;
 }
 
+/* file-icon – svg inlined here, but it should also be possible to separate out. */
 ul a::before {
-  content: '\f016';
-  font-family: FontAwesome;
+  content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><g><path fill='transparent' stroke='currentColor' stroke-width='4px' stroke-miterlimit='10' d='M50.46,56H13.54V8H35.85a4.38,4.38,0,0,1,3.1,1.28L49.18,19.52a4.38,4.38,0,0,1,1.28,3.1Z'/><polyline fill='transparent' stroke='currentColor' stroke-width='2px' stroke-miterlimit='10' points='35.29 8.31 35.29 23.03 49.35 23.03'/></g></svg>");
   display: inline-block;
+  vertical-align: middle;
   margin-right: 10px;
-  color: #000;
 }
 
 ul a:hover {
@@ -88,9 +88,9 @@ ul a[class=''] + i {
   display: none;
 }
 
+/* folder-icon */
 ul a[class='']::before {
-  content: '\f114';
-  font-size: 14px;
+  content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><path fill='transparent' stroke='currentColor' stroke-width='4px' stroke-miterlimit='10' d='M56,53.71H8.17L8,21.06a2.13,2.13,0,0,1,2.13-2.13h2.33l2.13-4.28A4.78,4.78,0,0,1,18.87,12h9.65a4.78,4.78,0,0,1,4.28,2.65l2.13,4.28H52.29a3.55,3.55,0,0,1,3.55,3.55Z'/></svg>");
 }
 
 @media (min-width: 768px) {

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -6,7 +6,6 @@
 
     <title>Files within {{directory}}</title>
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
     <link rel="stylesheet" href="{{assetDir}}/styles.css">
   </head>
 


### PR DESCRIPTION
hey all,
first of all thx for all of your great zeit-awesomeness.
I've wondered why to load the whole font-awesome-lib for just two icons (file and folder) and tried to solve that with svgs in css.

Would save about 75KB.

![before](https://cloud.githubusercontent.com/assets/64245/24440702/ebbb679e-1455-11e7-8a44-7718f53c23dc.jpg)

![after](https://cloud.githubusercontent.com/assets/64245/24440707/f23db5d6-1455-11e7-903d-fdfc9eff9783.jpg)

Hopefully you'll find it useful.
Just an idea.


