### PR TITLE
default mime type text/html for SPA

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -141,9 +141,9 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     return stream(req, indexPath, streamOptions).pipe(res)
   }
 
-  // Serve files without a mime type as text
+  // Serve files without a mime type as html for SPA, and text for non SPA
   // eslint-disable-next-line camelcase
-  stream.mime.default_type = 'text/plain'
+  stream.mime.default_type = flags.single ? 'text/html' : 'text/plain'
 
   return stream(
     req,


### PR DESCRIPTION
When refreshing a page in a SPA the page source is returned as text/plain.

This PR changes the content type to text/html if the single flag is set.