### PR TITLE
replace fs sync with async yield

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -69,7 +69,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
 
   related = decodeURIComponent(path.format(related))
 
-  const relatedExists = fs.existsSync(related)
+  const relatedExists = yield fs.exists(related)
   let notFoundResponse = 'Not Found'
 
   try {
@@ -88,7 +88,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   }
 
   // Check if directory
-  if (relatedExists && pathType.dirSync(related)) {
+  if (relatedExists && (yield pathType.dir(related))) {
     // Normalize path to trailing slash
     // Otherwise problems like #70 will occur
     const url = parse(req.url)
@@ -108,7 +108,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     let indexPath = path.join(related, '/index.html')
     res.setHeader('Content-Type', mime.contentType(path.extname(indexPath)))
 
-    if (!fs.existsSync(indexPath)) {
+    if (!(yield fs.exists(indexPath))) {
       // Try to render the current directory's content
       const port = flags.port || req.socket.localPort
       const renderedDir = yield renderDirectory(
@@ -136,7 +136,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     return stream(req, indexPath, streamOptions).pipe(res)
   }
 
-  if (!fs.existsSync(related) && flags.single) {
+  if (!(yield fs.exists(related)) && flags.single) {
     const indexPath = path.join(current, '/index.html')
     return stream(req, indexPath, streamOptions).pipe(res)
   }


### PR DESCRIPTION
I noticed some sync method calls to fs/fs-promise which unless I am missing something block the event loop for each http request.

This PR replaces them with async yield.