### PR TITLE
Add support for long-term caching of files with content-hashed filenames

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -39,6 +39,8 @@ args
     'Time in milliseconds for caching files in the browser',
     3600
   )
+  .option(['H', 'hash'], 'Long-cache URLs with embedded hashes', false)
+  .option('regexp', 'Long-cache hash RegExp', '\\.[0-9a-f]{8}\\.')
   .option('single', 'Serve single page apps with only one index.html')
   .option('unzipped', 'Disable GZIP compression')
   .option('ignore', 'Files and directories to ignore')
@@ -56,12 +58,22 @@ const flags = args.parse(process.argv, {
     alias: {
       a: 'auth',
       C: 'cors',
+      H: 'hash',
+      r: 'regexp',
       S: 'silent',
       s: 'single',
       u: 'unzipped',
       n: 'no-clipboard'
     },
-    boolean: ['auth', 'cors', 'silent', 'single', 'unzipped', 'no-clipboard']
+    boolean: [
+      'auth',
+      'cors',
+      'hash',
+      'silent',
+      'single',
+      'unzipped',
+      'no-clipboard'
+    ]
   }
 })
 
@@ -84,6 +96,10 @@ let ignoredFiles = ['.DS_Store', '.git/']
 
 if (flags.ignore && flags.ignore.length > 0) {
   ignoredFiles = ignoredFiles.concat(flags.ignore.split(','))
+}
+
+if (flags.hash) {
+  flags.regexp = new RegExp(flags.regexp)
 }
 
 const handler = coroutine(function*(req, res) {

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -13,10 +13,13 @@ module.exports = coroutine(function*(server, current, inUse, clipboard) {
   const details = server.address()
   const isTTY = process.stdout.isTTY
 
-  process.on('SIGINT', () => {
+  const shutdown = () => {
     server.close()
     process.exit(0)
-  })
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
 
   let isDir
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -87,6 +87,12 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     streamOptions.maxAge = flags.cache
   }
 
+  if (flags.hash) {
+    if (flags.regexp.test(req.url)) {
+      streamOptions.maxAge = 31536000000
+    }
+  }
+
   // Check if directory
   if (relatedExists && (yield pathType.dir(related))) {
     // Normalize path to trailing slash


### PR DESCRIPTION
Would this be useful to anyone else?

ETags are great but still require an If-None-Match/304 Not Modified request/response cycle. Tools like webpack are often configured to produce static assets with content-hashed filenames. The filename contains a hash of the file content, so when the content changes, the filename changes. For example, Create React App produces (via webpack) filenames like this:  `/static/js/main.54d5d5d6.js`. 

This pull request adds the boolean `--hash` option which enables detection of content-hashed filenames and serves the files with a max-age of 365 days. It also adds the `--regexp` option which can be used to change the default RegExp. The default RegExp matches the hash format used by Create React App.

https://webpack.js.org/guides/caching/#components/sidebar/sidebar.jsx
