### PR TITLE
Closes zeit/serve#159

### DIFF
--- a/lib/listening.js
+++ b/lib/listening.js
@@ -12,7 +12,7 @@ const { coroutine } = require('bluebird')
 module.exports = coroutine(function*(server, current, inUse, clipboard) {
   const details = server.address()
   const isTTY = process.stdout.isTTY
-  
+
   const shutdown = () => {
     server.close()
     process.exit(0)

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -12,11 +12,14 @@ const { coroutine } = require('bluebird')
 module.exports = coroutine(function*(server, current, inUse, clipboard) {
   const details = server.address()
   const isTTY = process.stdout.isTTY
-
-  process.on('SIGINT', () => {
+  
+  const shutdown = () => {
     server.close()
     process.exit(0)
-  })
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
 
   let isDir
 


### PR DESCRIPTION
Closes zeit/serve#159

Shut down server on both SIGTERM and SIGINT to support Docker as `docker stop` sends SIGTERM to PID 1.

Be sure to use the exec form of the CMD instruction to get serve on PID 1:

`CMD [ "serve", "-s", "build", "-p", "80" ]`

The shell form of the CMD instruction puts serve on PID 2, which won't work:

`CMD serve -s build -p 80`

See this for more info: https://www.ctl.io/developers/blog/post/gracefully-stopping-docker-containers/