### PR TITLE
Add default caching options when serving with single flag

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -34,12 +34,11 @@ if (process.env.NODE_ENV !== 'production' && pkg.dist) {
 
 args
   .option('port', 'Port to listen on', process.env.PORT || 5000)
+  .option('cache', 'Time in milliseconds for caching files in the browser')
   .option(
-    'cache',
-    'Time in milliseconds for caching files in the browser',
-    3600
+    'single',
+    'Serve single page apps with only one index.html. Sets cache for 1 day.'
   )
-  .option('single', 'Serve single page apps with only one index.html')
   .option('unzipped', 'Disable GZIP compression')
   .option('ignore', 'Files and directories to ignore')
   .option('auth', 'Serve behind basic auth')
@@ -62,7 +61,15 @@ const flags = args.parse(process.argv, {
       n: 'no-clipboard',
       o: 'open'
     },
-    boolean: ['auth', 'cors', 'silent', 'single', 'unzipped', 'no-clipboard', 'open']
+    boolean: [
+      'auth',
+      'cors',
+      'silent',
+      'single',
+      'unzipped',
+      'no-clipboard',
+      'open'
+    ]
   }
 })
 
@@ -109,7 +116,13 @@ detect(port).then(open => {
   server.listen(
     port,
     coroutine(function*() {
-      yield listening(server, current, inUse, flags.noClipboard !== true, flags.open)
+      yield listening(
+        server,
+        current,
+        inUse,
+        flags.noClipboard !== true,
+        flags.open
+      )
     })
   )
 })

--- a/lib/server.js
+++ b/lib/server.js
@@ -93,6 +93,12 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     streamOptions.maxAge = flags.cache
   }
 
+  if (!flags.cache && flags.single) {
+    // Default to 1 day for SPAs
+    // index.html defaults to 0
+    streamOptions.maxAge = '8640000'
+  }
+
   // Check if directory
   if (relatedExists && (yield pathType.dir(related))) {
     // Normalize path to trailing slash
@@ -139,10 +145,15 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
       indexPath = path.join(current, '/index.html')
     }
 
+    if (flags.single && indexPath === path.join(current, '/index.html')) {
+      streamOptions.maxAge = 0 // Don't cache SPA index
+    }
+
     return stream(req, indexPath, streamOptions).pipe(res)
   }
 
   if (!(yield fs.exists(related)) && flags.single) {
+    streamOptions.maxAge = 0 // Don't cache SPA index
     const indexPath = path.join(current, '/index.html')
     return stream(req, indexPath, streamOptions).pipe(res)
   }


### PR DESCRIPTION
Closes #208

For deploys with the `single` flag, it changes the `cache-control max-age` to `0` for `index.html`, and 1 day for everything else.  

You can still overwrite the max-age with the `cache` flag, even when deploying with `single` flag, however it will keep index.html at `max-age 0`

I also removed the defaulting of caching being 3600ms (approx 3seconds) as that seemed pointless. Instead just lets micro decide on the default?

This is an alternative to #190. Either works, but would like to see caching done better for SPAs :)