### PR TITLE
Fixed custom 404 pages

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -83,7 +83,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   }
 
   const relatedExists = yield fs.exists(related)
-  if (!relatedExists && flags.single === undefined) {
+  if (!relatedExists && !flags.single) {
     return micro.send(res, 404, notFoundResponse)
   }
 


### PR DESCRIPTION
This PR fixes an issue with `serve v5.2.2` where a custom 404 page (ie. `404.html`) wasn't being sent.

From my triaging, it seems like the issue is with [this line](https://github.com/zeit/serve/blob/8d556096d8ccca2409ee3b0d30fc3ac862a1c08b/lib/server.js#L86), which checks if `flags.single === undefined`. Since the default value is actually `false` this block never gets triggered and we never end up sending the custom 404 page.

This change doesn't _seem_ to introduce regressions even with different options, but it's hard to actually tell without automated tests 😢 