### PR TITLE
add a new json flag to list directory as json content

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -40,6 +40,7 @@ args
     3600
   )
   .option('single', 'Serve single page apps with only one index.html')
+  .option('json', 'Use JSON to list directories')
   .option('unzipped', 'Disable GZIP compression')
   .option('ignore', 'Files and directories to ignore')
   .option('auth', 'Serve behind basic auth')
@@ -58,11 +59,21 @@ const flags = args.parse(process.argv, {
       C: 'cors',
       S: 'silent',
       s: 'single',
+      j: 'json',
       u: 'unzipped',
       n: 'no-clipboard',
       o: 'open'
     },
-    boolean: ['auth', 'cors', 'silent', 'single', 'unzipped', 'no-clipboard', 'open']
+    boolean: [
+      'auth',
+      'cors',
+      'silent',
+      'single',
+      'json',
+      'unzipped',
+      'no-clipboard',
+      'open'
+    ]
   }
 })
 
@@ -109,7 +120,13 @@ detect(port).then(open => {
   server.listen(
     port,
     coroutine(function*() {
-      yield listening(server, current, inUse, flags.noClipboard !== true, flags.open)
+      yield listening(
+        server,
+        current,
+        inUse,
+        flags.noClipboard !== true,
+        flags.open
+      )
     })
   )
 })

--- a/lib/render.js
+++ b/lib/render.js
@@ -10,7 +10,13 @@ const { coroutine } = require('bluebird')
 // Ours
 const prepareView = require('./view')
 
-module.exports = coroutine(function*(port, current, dir, ignoredFiles) {
+module.exports = coroutine(function*(
+  port,
+  current,
+  dir,
+  ignoredFiles,
+  renderJson
+) {
   let files = []
   const subPath = path.relative(current, dir)
 
@@ -70,7 +76,7 @@ module.exports = coroutine(function*(port, current, dir, ignoredFiles) {
     })
   }
 
-  const render = prepareView()
+  const render = prepareView(renderJson)
 
   const paths = []
   pathParts.pop()

--- a/lib/server.js
+++ b/lib/server.js
@@ -121,11 +121,15 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
         port,
         current,
         related,
-        ignoredFiles
+        ignoredFiles,
+        flags.json
       )
 
       // If it works, send the directory listing to the user
       if (renderedDir) {
+        if (flags.json) {
+          res.setHeader('Content-Type', 'application/json')
+        }
         return micro.send(res, 200, renderedDir)
       }
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -5,7 +5,21 @@ const path = require('path')
 const fs = require('fs-extra')
 const { compile } = require('handlebars')
 
-module.exports = () => {
+function jsonRenderer(details) {
+  const files = details.files.map(
+    ({ base, ext, name, relative, size, title }) => {
+      return { base, ext, name, relative, size, title }
+    }
+  )
+
+  return { files }
+}
+
+module.exports = renderJson => {
+  if (renderJson) {
+    return jsonRenderer
+  }
+
   let viewContent = false
   const viewPath = path.normalize(path.join(__dirname, '/../views/index.hbs'))
 


### PR DESCRIPTION
Hi,

this is an attempt at adding a new flag, `json`, which would allow serving a directory listing, not with the current hbs template, but using a JSON format.

This is pretty useful at a tool for development purpose.

Let me know what you think about it.