### PR TITLE
Disable cache when `--cache` is set to `0`.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -95,6 +95,11 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
 
   if (flags.cache) {
     streamOptions.maxAge = flags.cache
+  } else if (flags.cache === 0) {
+    // Disable the cache control by `send`, as there's no support for `no-cache`.
+    // Set header manually.
+    streamOptions.cacheControl = false
+    res.setHeader('Cache-Control', 'no-cache')
   } else if (flags.single) {
     // Cache assets of single page applications for a day.
     // Later in the code, we'll define that `index.html` never


### PR DESCRIPTION
This implements #224 and sets a `Cache-Control: no-cache` header when serving with `serve -c 0` or `serve -s -c 0`. Had to manually set it because `send` doesn't allow string values for `cacheControl`.