### PR TITLE
fix missing zero in one day cache number

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -104,7 +104,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     // Cache assets of single page applications for a day.
     // Later in the code, we'll define that `index.html` never
     // gets cached!
-    streamOptions.maxAge = 8640000
+    streamOptions.maxAge = 86400000
   }
 
   // Check if directory


### PR DESCRIPTION
86400000 milliseconds is 1 day

https://www.google.com.au/search?q=86400000+milliseconds+to+days&spell=1&sa=X&ved=0ahUKEwiTmITf1Z7VAhXMpJQKHUojDWwQvwUIIygA&biw=1440&bih=776