### PR TITLE
Added HTTP 404 to non-existent files in SPA mode

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -168,11 +168,16 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   // - The path matches exactly `/index.html`
   if (
     flags.single &&
-      (!(yield fs.exists(related)) ||
+    (!(yield fs.exists(related)) ||
       related === path.join(current, '/index.html'))
   ) {
     // Don't cache the `index.html` file for single page applications
     streamOptions.maxAge = 0
+
+    // Set HTTP 404 since there is not an actual file.
+    if (pathname !== '/index.html') {
+      res.statusCode = 404
+    }
 
     // Load `index.html` and send it to the client
     const indexPath = path.join(current, '/index.html')


### PR DESCRIPTION
Hello,

I have seen issue #257 and wanted to contribute again. I think it would be better if we return HTTP 404 for non-existent files in SPA mode. Also, I believe that it shouldn't be a problem for SPAs since there is nothing to be crawled regarding to non-existent files by bots.

I am happy to apply any other approach if there is.