### PR TITLE
Added icons for image files (#285)

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -116,6 +116,15 @@ ul a[class='']::before {
   content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><path fill='transparent' stroke='currentColor' stroke-width='4px' stroke-miterlimit='10' d='M56,53.71H8.17L8,21.06a2.13,2.13,0,0,1,2.13-2.13h2.33l2.13-4.28A4.78,4.78,0,0,1,18.87,12h9.65a4.78,4.78,0,0,1,4.28,2.65l2.13,4.28H52.29a3.55,3.55,0,0,1,3.55,3.55Z'/></svg>");
 }
 
+/* image-icon */
+ul a[class='gif']::before,
+ul a[class='jpg']::before,
+ul a[class='png']::before,
+ul a[class='svg']::before {
+  content: url("data:image/svg+xml; utf8, <svg width='16' height='16' viewBox='0 0 80 80' version='1.1' xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-width='5'  stroke-linecap='round' stroke-linejoin='round'><rect x='6' y='6' width='68' height='68' rx='5' ry='5'></rect><circle cx='24' cy='24' r='8'></circle><polyline points='73 49 59 34 37 52'></polyline><polyline points='53 72 27 42 7 58'></polyline></svg>");
+  width: 16px;
+}
+
 @media (min-width: 768px) {
   #toggle {
     display: inline-block;


### PR DESCRIPTION
Currently images & files have the same icon:
![before-change](https://user-images.githubusercontent.com/8844886/32138979-5deae9fe-bbf2-11e7-8445-e84501b94f03.png)

With this change, we will have a fancy icon to differentiate images (.gif, .jpg, .png, .svg) from other types of files:
![after-change](https://user-images.githubusercontent.com/8844886/32138980-5e020468-bbf2-11e7-9123-cfe58ea059af.png)
