### PR TITLE
Optimize SVG icons

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -97,7 +97,7 @@ ul a {
 
 /* file-icon – svg inlined here, but it should also be possible to separate out. */
 ul a::before {
-  content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><g><path fill='transparent' stroke='currentColor' stroke-width='4px' stroke-miterlimit='10' d='M50.46,56H13.54V8H35.85a4.38,4.38,0,0,1,3.1,1.28L49.18,19.52a4.38,4.38,0,0,1,1.28,3.1Z'/><polyline fill='transparent' stroke='currentColor' stroke-width='2px' stroke-miterlimit='10' points='35.29 8.31 35.29 23.03 49.35 23.03'/></g></svg>");
+  content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><g fill='transparent' stroke='currentColor' stroke-miterlimit='10'><path stroke-width='4' d='M50.46 56H13.54V8h22.31a4.38 4.38 0 0 1 3.1 1.28l10.23 10.24a4.38 4.38 0 0 1 1.28 3.1z'/><path stroke-width='2' d='M35.29 8.31v14.72h14.06'/></g></svg>");
   display: inline-block;
   vertical-align: middle;
   margin-right: 10px;
@@ -113,7 +113,7 @@ ul a[class=''] + i {
 
 /* folder-icon */
 ul a[class='']::before {
-  content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><path fill='transparent' stroke='currentColor' stroke-width='4px' stroke-miterlimit='10' d='M56,53.71H8.17L8,21.06a2.13,2.13,0,0,1,2.13-2.13h2.33l2.13-4.28A4.78,4.78,0,0,1,18.87,12h9.65a4.78,4.78,0,0,1,4.28,2.65l2.13,4.28H52.29a3.55,3.55,0,0,1,3.55,3.55Z'/></svg>");
+  content: url("data:image/svg+xml; utf8, <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 64 64'><path fill='transparent' stroke='currentColor' stroke-width='4' stroke-miterlimit='10' d='M56 53.71H8.17L8 21.06a2.13 2.13 0 0 1 2.13-2.13h2.33l2.13-4.28A4.78 4.78 0 0 1 18.87 12h9.65a4.78 4.78 0 0 1 4.28 2.65l2.13 4.28h17.36a3.55 3.55 0 0 1 3.55 3.55z'/></svg>");
 }
 
 /* image-icon */
@@ -121,7 +121,7 @@ ul a[class='gif']::before,
 ul a[class='jpg']::before,
 ul a[class='png']::before,
 ul a[class='svg']::before {
-  content: url("data:image/svg+xml; utf8, <svg width='16' height='16' viewBox='0 0 80 80' version='1.1' xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-width='5'  stroke-linecap='round' stroke-linejoin='round'><rect x='6' y='6' width='68' height='68' rx='5' ry='5'></rect><circle cx='24' cy='24' r='8'></circle><polyline points='73 49 59 34 37 52'></polyline><polyline points='53 72 27 42 7 58'></polyline></svg>");
+  content: url("data:image/svg+xml; utf8, <svg width='16' height='16' viewBox='0 0 80 80' xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-width='5' stroke-linecap='round' stroke-linejoin='round'><rect x='6' y='6' width='68' height='68' rx='5' ry='5'/><circle cx='24' cy='24' r='8'/><path d='M73 49L59 34 37 52M53 72L27 42 7 58'/></svg>");
   width: 16px;
 }
 


### PR DESCRIPTION
I’ve used svgo to optimize the SVG icons embedded in `serve`’s stylesheet. No visual change but shaves off a few bytes 👍

Let me know if I should make any changes!