### PR TITLE
Compare flags.cache to the string '0', not 0

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -95,7 +95,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
 
   if (flags.cache) {
     streamOptions.maxAge = flags.cache
-  } else if (flags.cache === 0) {
+  } else if (flags.cache === '0') {
     // Disable the cache control by `send`, as there's no support for `no-cache`.
     // Set header manually.
     streamOptions.cacheControl = false


### PR DESCRIPTION
The logic in https://github.com/zeit/serve/pull/245 is faulty, as `flags` is set via

```js
const flags = args.parse(process.argv, { minimist })
```

and that will assign a string representation of all of the flag values.

This PR updates the code to handle `-c 0` by doing the comparison against the string `'0'` instead of the number `0`, to account for the fact that `flags.cache` is a string.