### PR TITLE
Disable caching for /sw.js and /service-worker.js in SPA mode.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -101,10 +101,20 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     streamOptions.cacheControl = false
     res.setHeader('Cache-Control', 'no-cache')
   } else if (flags.single) {
-    // Cache assets of single page applications for a day.
-    // Later in the code, we'll define that `index.html` never
-    // gets cached!
-    streamOptions.maxAge = 86400000
+    // Special logic for files that look like service workers in SPA mode:
+    // See https://github.com/zeit/serve/issues/299
+    if (
+      pathname.endsWith('/service-worker.js') ||
+      pathname.endsWith('/sw.js')
+    ) {
+      streamOptions.cacheControl = false
+      res.setHeader('Cache-Control', 'no-cache')
+    } else {
+      // Cache assets of single page applications for a day.
+      // Later in the code, we'll define that `index.html` never
+      // gets cached!
+      streamOptions.maxAge = 86400000
+    }
   }
 
   // Check if directory
@@ -168,7 +178,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   // - The path matches exactly `/index.html`
   if (
     flags.single &&
-      (!(yield fs.exists(related)) ||
+    (!(yield fs.exists(related)) ||
       related === path.join(current, '/index.html'))
   ) {
     // Don't cache the `index.html` file for single page applications


### PR DESCRIPTION
I'm not sure if the maintainers are open to this, but if you are, this fixes #299.