### PR TITLE
Recycle output of call to fs

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -168,8 +168,7 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   // - The path matches exactly `/index.html`
   if (
     flags.single &&
-      (!(yield fs.exists(related)) ||
-      related === path.join(current, '/index.html'))
+    (!relatedExists || related === path.join(current, '/index.html'))
   ) {
     // Don't cache the `index.html` file for single page applications
     streamOptions.maxAge = 0


### PR DESCRIPTION
There was already a variable set to the result of the call to `yield fs.exists(related)`. Rather than call the same file system operation twice, I recycled the result of the first call. It's a tiny optimization.