### PR TITLE
Fixed typo in option alias

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -7,7 +7,7 @@ const dargs = require('dargs')
 
 module.exports = (directory = process.cwd(), options = {}) => {
   const scriptPath = path.join(__dirname, '..', 'bin', 'serve.js')
-  const aliases = { cors: 'o' }
+  const aliases = { cors: 'C' }
 
   options._ = [directory] // Let dargs handle the directory argument
 


### PR DESCRIPTION
Currently it interprets {cors:true} option as open:true, which is not expected by users.
Fixes https://github.com/zeit/serve/issues/296