### PR TITLE
Download directory as zip feature

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -146,7 +146,8 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
         const archive = yield zipDirectory(current, related, ignoredFiles)
         let name = path.relative(current, related)
         name = name.substr(name.lastIndexOf('/') + 1)
-        archive.writeToResponse(res, name || 'root')
+        const rootName = current.substr(current.lastIndexOf('/') + 1)
+        archive.writeToResponse(res, name || rootName)
         return res
       }
       // Try to render the current directory's content

--- a/lib/server.js
+++ b/lib/server.js
@@ -15,6 +15,7 @@ const isPathInside = require('path-is-inside')
 
 // Utilities
 const renderDirectory = require('./render')
+const zipDirectory = require('./zip')
 
 module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   const headers = {}
@@ -139,6 +140,15 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     res.setHeader('Content-Type', mime.contentType(path.extname(indexPath)))
 
     if (!(yield fs.exists(indexPath))) {
+      if (url.query === 'download') {
+        // Compress current directory in zip archive
+        // and send.
+        const archive = yield zipDirectory(current, related, ignoredFiles)
+        let name = path.relative(current, related)
+        name = name.substr(name.lastIndexOf('/') + 1)
+        archive.writeToResponse(res, name || 'root')
+        return res
+      }
       // Try to render the current directory's content
       const port = flags.port || req.socket.localPort
       const renderedDir = yield renderDirectory(

--- a/lib/zip.js
+++ b/lib/zip.js
@@ -1,0 +1,54 @@
+// Packages
+const fs = require('fs-extra')
+const { coroutine } = require('bluebird')
+const FolderZip = require('folder-zip')
+
+module.exports = coroutine(function*(current, dir, ignoredFiles) {
+  let files = []
+
+  if (!fs.existsSync(dir)) {
+    return false
+  }
+
+  try {
+    files = yield fs.readdir(dir)
+  } catch (err) {
+    throw err
+  }
+
+  const archive = new FolderZip()
+
+  const promises = []
+  for (let file of files) {
+    const fullPath = dir + '/' + file
+
+    let fileStats
+    try {
+      fileStats = yield fs.stat(fullPath)
+    } catch (err) {
+      throw err
+    }
+
+    if (fileStats.isDirectory()) file += '/'
+
+    if (ignoredFiles.indexOf(file) > -1) {
+      continue
+    }
+
+    promises.push(
+      new Promise((resolve, reject) => {
+        function zipCallBack(error, zip) {
+          if (error) reject(error)
+          else resolve(zip)
+        }
+        if (fileStats.isDirectory())
+          archive.zipFolder(fullPath, {}, zipCallBack)
+        else archive.addFile(file, fullPath, zipCallBack)
+      })
+    )
+  }
+
+  yield Promise.all(promises)
+
+  return archive
+})

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "dargs": "5.1.0",
     "detect-port": "1.2.2",
     "filesize": "3.5.11",
+    "folder-zip": "0.0.5",
     "fs-extra": "5.0.0",
     "handlebars": "4.0.11",
     "ip": "1.1.5",

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -22,6 +22,7 @@
 
         <a class="single-column" id="toggle" title="click to toggle the view"></a>
       </header>
+      <a title="Download this directory as zip archive" href="?download">Download</a>
 
       <ul id="files">
         {{#each files}}


### PR DESCRIPTION
Now user could download an open folder entirely as zip archive, which is comfortably, when you share a lot of files. 
![default](https://user-images.githubusercontent.com/32711843/35917436-323e322a-0c1f-11e8-848b-a3859166f84b.png)
I could not create nice button for downloading, which really fit for view page, but I'm ready to fix it, if anyone tell me how create beautiful icon or something else.