### PR TITLE
Temporary work around `mime-types` limitation

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,6 +16,12 @@ const isPathInside = require('path-is-inside')
 // Utilities
 const renderDirectory = require('./render')
 
+// Register the mime type for `.wasm` files. This change is currently not
+// possible on upstream because of an unrelated issue. Once `mime-types` is 
+// updated, this line can be removed.
+// https://github.com/jshttp/mime-types/issues/44
+mime.types['wasm'] = 'application/wasm'
+
 module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   const headers = {}
 


### PR DESCRIPTION
This will temporarily add a mime type for `.wasm` files as per suggestion in https://github.com/jshttp/mime-types/issues/44#issuecomment-365326416. As soon as an update to the upstream library is made, this change can be removed again.