### PR TITLE
Fixes wrong mime type for `.wasm` files

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -192,9 +192,9 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   //
   // Details:
   // Register the mime type for `.wasm` files. This change is currently not
-  // possible on upstream because of an unrelated issue. Once `mime-types` is
+  // possible on upstream because of an unrelated issue. Once `mime` is
   // updated, this line can be removed.
-  // https://github.com/jshttp/mime-types/issues/44
+  // https://github.com/pillarjs/send/pull/154
   stream.mime.types.wasm = 'application/wasm'
   stream.mime.extensions['application/wasm'] = 'wasm'
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -188,6 +188,16 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
     return stream(req, indexPath, streamOptions).pipe(res)
   }
 
+  // TODO remove the change below when https://github.com/zeit/serve/issues/303 is fixed.
+  //
+  // Details:
+  // Register the mime type for `.wasm` files. This change is currently not
+  // possible on upstream because of an unrelated issue. Once `mime-types` is
+  // updated, this line can be removed.
+  // https://github.com/jshttp/mime-types/issues/44
+  stream.mime.types.wasm = 'application/wasm'
+  stream.mime.extensions['application/wasm'] = 'wasm'
+
   // Serve files without a mime type as html for SPA, and text for non SPA
   // eslint-disable-next-line camelcase
   stream.mime.default_type = flags.single ? 'text/html' : 'text/plain'


### PR DESCRIPTION
Fixes #303 

@leo this is a temporary fix. If you don't want to merge I can use a fork.