### PR TITLE
Add object and array destructuring on XO reported errors

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -44,7 +44,7 @@ args.options(options)
 const flags = args.parse(process.argv, { minimist })
 
 // Figure out the content directory
-const directory = args.sub[0]
+const [directory] = args.sub
 
 // Don't log anything to the console if silent mode is enabled
 if (flags.silent) {
@@ -83,7 +83,7 @@ const server = flags.ssl
   ? microHttps(flags.unzipped ? handler : compress(handler))
   : micro(flags.unzipped ? handler : compress(handler))
 
-let port = flags.port
+let { port } = flags
 
 detect(port).then(open => {
   let inUse = open !== port

--- a/lib/listening.js
+++ b/lib/listening.js
@@ -20,7 +20,7 @@ module.exports = coroutine(function*(
   isLocal
 ) {
   const details = server.address()
-  const isTTY = process.stdout.isTTY
+  const { isTTY } = process.stdout
 
   const shutdown = () => {
     server.close()


### PR DESCRIPTION
This fix allows to pass Travis builds again.