### PR TITLE
Ensure `0` cache value triggers no cache

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -103,13 +103,13 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
 
   const streamOptions = {}
 
-  if (flags.cache) {
+  if (flags.cache > 0) {
     streamOptions.maxAge = flags.cache
-  } else if (flags.cache === 0) {
+  } else if (flags.cache === 0 || flags.cache === '0') {
     // Disable the cache control by `send`, as there's no support for `no-cache`.
     // Set header manually.
     streamOptions.cacheControl = false
-    res.setHeader('Cache-Control', 'no-cache')
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate')
   } else if (flags.single) {
     // Cache assets of single page applications for a day.
     // Later in the code, we'll define that `index.html` never

--- a/lib/server.js
+++ b/lib/server.js
@@ -102,10 +102,11 @@ module.exports = coroutine(function*(req, res, flags, current, ignoredFiles) {
   }
 
   const streamOptions = {}
+  const cacheValue = parseInt(flags.cache, 10)
 
-  if (flags.cache > 0) {
+  if (cacheValue > 0) {
     streamOptions.maxAge = flags.cache
-  } else if (flags.cache === 0 || flags.cache === '0') {
+  } else if (cacheValue === 0) {
     // Disable the cache control by `send`, as there's no support for `no-cache`.
     // Set header manually.
     streamOptions.cacheControl = false


### PR DESCRIPTION
For some reason, setting a cache value of 0 in both the CLI and the API returns the value as a string.
The `args` package must not treat 0 as a number for some reason.

Also modified Cache-Control header for preventing caching to be more aggressive by setting the no-store and must-revalidate options as Chrome was still accessing assets using the cache.