### PR TITLE
Ensure serve starts even if update check fails

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -15,6 +15,7 @@ const {red, bold} = require('chalk');
 const nodeVersion = require('node-version');
 const cert = require('openssl-self-signed-certificate');
 const boxen = require('boxen');
+const promiseTimeout = require('promise-timeout');
 
 // Utilities
 const pkg = require('../package');
@@ -85,7 +86,7 @@ detect(port).then(async open => {
 
 	if (NODE_ENV !== 'production') {
 		try {
-			const update = await checkForUpdate(pkg);
+			const update = await promiseTimeout.timeout(checkForUpdate(pkg), 2000);
 
 			if (update) {
 				const message = `${bold(

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -84,19 +84,33 @@ detect(port).then(async open => {
 	const {NODE_ENV} = process.env;
 
 	if (NODE_ENV !== 'production') {
-		const update = await checkForUpdate(pkg);
+		try {
+			const update = await checkForUpdate(pkg);
 
-		if (update) {
-			const message = `${bold(
-				'UPDATE AVAILABLE:'
-			)} The latest version of \`serve\` is ${update.latest}`;
+			if (update) {
+				const message = `${bold(
+					'UPDATE AVAILABLE:'
+				)} The latest version of \`serve\` is ${update.latest}`;
 
+				console.log(
+					boxen(message, {
+						padding: 1,
+						borderColor: 'green',
+						margin: 1
+					})
+				);
+			}
+		} catch (err) {
 			console.log(
-				boxen(message, {
-					padding: 1,
-					borderColor: 'green',
-					margin: 1
-				})
+				boxen(
+					`${bold(
+						'UPDATE CHECK FAILED:'
+					)} ${err.message}`, {
+						padding: 1,
+						borderColor: 'red',
+						margin: 1
+					}
+				)
 			);
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "opn": "5.3.0",
     "path-is-inside": "1.0.2",
     "path-type": "3.0.0",
+    "promise-timeout": "1.3.0",
     "send": "0.16.2",
     "update-check": "1.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,6 +3185,10 @@ progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+promise-timeout@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/promise-timeout/-/promise-timeout-1.3.0.tgz#d1c78dd50a607d5f0a5207410252a3a0914e1014"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"


### PR DESCRIPTION
We use `serve` for our e2e tests and after upgrading recently noticed CI failures because of the update check that happens before starting the server. We are sitting behind a corporate proxy and the `update-check` module does not seem to respect the proxy environment variables.

After around 30 seconds `connect` throws a `ETIMEDOUT` exception that is not being handled and thus the server does not start.

This pull request catches errors occuring in update check to ensure `serve` is started even if the update check fails. Additionally it adds a timeout to the update check call to wait no more than 2 seconds for it to complete.