### PR TITLE
Adjusted `engines` field to match readme

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "serve": "./bin/serve.js"
   },
   "engines": {
-    "node": ">=6.9.0"
+    "node": ">=7.6.0"
   },
   "keywords": [
     "now",


### PR DESCRIPTION
Previously, the field was not matching (as described in https://github.com/zeit/serve/issues/349).

This closes #349.