### PR TITLE
Bumped `serve-handler` to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ajv": "6.5.0",
     "arg": "2.0.0",
     "chalk": "2.4.1",
-    "serve-handler": "2.3.10",
+    "serve-handler": "2.3.11",
     "update-check": "1.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,9 +804,9 @@ semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-serve-handler@2.3.10:
-  version "2.3.10"
-  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-2.3.10.tgz#d4a953d5f0ce8d1a936f91f4f182e1f6d626f273"
+serve-handler@2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-2.3.11.tgz#e04b5950b7f7874adc47474ac75347dc79ceb097"
   dependencies:
     bytes "3.0.0"
     fast-url-parser "1.1.3"


### PR DESCRIPTION
This fixes https://github.com/zeit/serve/issues/378.