### PR TITLE
Re-added `--single` and made `--listen` support ports

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -70,6 +70,8 @@ const getHelp = () => chalk`
 
       -d, --debug                         Show debugging information
 
+      -s, --single                        Rewrite all requests to \`index.html\`
+
   {bold ENDPOINTS}
 
       Listen endpoints (specified by the {bold --listen} or {bold -l} options above) instruct {cyan serve}
@@ -237,11 +239,13 @@ const loadConfig = async (cwd, entry) => {
 			'--help': Boolean,
 			'--version': Boolean,
 			'--listen': [parseEndpoint],
+			'--single': Boolean,
 			'--debug': Boolean,
 			'-h': '--help',
 			'-v': '--version',
 			'-l': '--listen',
-			'-d': '--debug'
+			'-d': '--debug',
+			'-s': '--single'
 		});
 	} catch (err) {
 		console.error(error(err.message));
@@ -274,6 +278,17 @@ const loadConfig = async (cwd, entry) => {
 	const entry = args._.length > 0 ? path.join(cwd, args._[0]) : cwd;
 
 	const config = await loadConfig(cwd, entry);
+
+	if (args['--single']) {
+		const {rewrites} = config;
+		const existingRewrites = Array.isArray(rewrites) ? rewrites : [];
+
+		// As the first rewrite rule, make `--single` work
+		config.rewrites = [{
+			source: '**',
+			destination: '/index.html'
+		}, ...existingRewrites];
+	}
 
 	for (const endpoint of args['--listen']) {
 		startEndpoint(endpoint, config);

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -70,7 +70,7 @@ const getHelp = () => chalk`
 
       -d, --debug                         Show debugging information
 
-      -s, --single                        Rewrite all requests to \`index.html\`
+      -s, --single                        Rewrite all not-found requests to \`index.html\`
 
   {bold ENDPOINTS}
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -77,6 +77,10 @@ const getHelp = () => chalk`
       Listen endpoints (specified by the {bold --listen} or {bold -l} options above) instruct {cyan serve}
       to listen on one or more interfaces/ports, UNIX domain sockets, or Windows named pipes.
 
+      For TCP ports on hostname "localhost":
+
+          {bold $} {cyan serve} -l {underline 1234}
+
       For TCP (traditional host/port) endpoints:
 
           {bold $} {cyan serve} -l tcp://{underline hostname}:{underline 1234}
@@ -91,6 +95,10 @@ const getHelp = () => chalk`
 `;
 
 const parseEndpoint = str => {
+	if (!isNaN(str)) {
+		return [str];
+	}
+
 	const url = new URL(str);
 
 	switch (url.protocol) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ajv": "6.5.0",
     "arg": "2.0.0",
     "chalk": "2.4.1",
-    "serve-handler": "2.3.11",
+    "serve-handler": "2.3.12",
     "update-check": "1.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,9 +804,9 @@ semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-serve-handler@2.3.11:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-2.3.11.tgz#e04b5950b7f7874adc47474ac75347dc79ceb097"
+serve-handler@2.3.12:
+  version "2.3.12"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-2.3.12.tgz#7c4f402753c74a7ff33b8607130b28bc45a07222"
   dependencies:
     bytes "3.0.0"
     fast-url-parser "1.1.3"


### PR DESCRIPTION
As per #382 (and a discussion with @gaearon), I have concluded that we should re-add the `--single` flag, now that we can simply add non-hacky rewrite rules.

Furthermore, this PR also allows for `--listen <port>`, so that people don't have to type `tcp://localhost:<port>`, effectively making it easier to get started with the package.