### PR TITLE
Bumped middleware to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ajv": "6.5.0",
     "arg": "2.0.0",
     "chalk": "2.4.1",
-    "serve-handler": "2.3.13",
+    "serve-handler": "2.3.15",
     "update-check": "1.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -664,7 +664,7 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1, path-is-inside@^1.0.2:
+path-is-inside@1.0.2, path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
@@ -804,15 +804,16 @@ semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-serve-handler@2.3.13:
-  version "2.3.13"
-  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-2.3.13.tgz#f897dd1d2af7003c0e7e9e84b55e3dd4ef51d6bb"
+serve-handler@2.3.15:
+  version "2.3.15"
+  resolved "https://registry.yarnpkg.com/serve-handler/-/serve-handler-2.3.15.tgz#cf79316409107c0175f7e78fe78b9e2c6d7fc285"
   dependencies:
     bytes "3.0.0"
     fast-url-parser "1.1.3"
     glob-slasher "1.0.1"
     mime "2.3.1"
     minimatch "3.0.4"
+    path-is-inside "1.0.2"
     path-to-regexp "2.2.1"
 
 shebang-command@^1.2.0:


### PR DESCRIPTION
This adds support for https://github.com/zeit/serve-handler/pull/14.