### PR TITLE
Show server listen address properly

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -156,7 +156,7 @@ const startEndpoint = (endpoint, config) => {
 		if (typeof details === 'string') {
 			console.log(info(`Accepting connections at ${details}`));
 		} else if (typeof details === 'object' && details.port) {
-			console.log(info(`Accepting connections at http://localhost:${details.port}`));
+			console.log(info(`Accepting connections at http://${details.address}:${details.port}`));
 		} else {
 			console.log(info('Accepting connections'));
 		}


### PR DESCRIPTION
When a listen address is specified as `-l tcp://addr:port`, the listen address is always shown as `localhost`, instead of what is specified in `addr`.