### PR TITLE
Add `--config` for custom paths to `serve.json`

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -54,8 +54,8 @@ const getHelp = () => chalk`
       {bold $} {cyan serve} --version
       {bold $} {cyan serve} [-l {underline listen_uri} [-l ...]] [{underline directory}]
 
-      By default, {cyan serve} will listen on {bold 0.0.0.0:3000} and serve the
-      current working directory on that address.
+      By default, {cyan serve} will listen on {bold 0.0.0.0:3000} and serve the current working directory 
+      on that address.
 
       Specifying a single {bold --listen} argument will overwrite the default, not supplement it.
 
@@ -71,6 +71,8 @@ const getHelp = () => chalk`
       -d, --debug                         Show debugging information
 
       -s, --single                        Rewrite all not-found requests to \`index.html\`
+
+      -c, --config                        Specify custom path to \`serve.json\`
 
   {bold ENDPOINTS}
 
@@ -164,12 +166,16 @@ const startEndpoint = (endpoint, config) => {
 	});
 };
 
-const loadConfig = async (cwd, entry) => {
+const loadConfig = async (cwd, entry, args) => {
 	const files = [
 		'serve.json',
 		'now.json',
 		'package.json'
 	];
+
+	if (args['--config']) {
+		files.unshift(args['--config']);
+	}
 
 	const config = {};
 
@@ -250,11 +256,13 @@ const loadConfig = async (cwd, entry) => {
 			'--listen': [parseEndpoint],
 			'--single': Boolean,
 			'--debug': Boolean,
+			'--config': String,
 			'-h': '--help',
 			'-v': '--version',
 			'-l': '--listen',
-			'-d': '--debug',
 			'-s': '--single',
+			'-d': '--debug',
+			'-c': '--config',
 			// This is deprecated and only for backwards-compatibility.
 			'-p': '--listen'
 		});
@@ -288,7 +296,7 @@ const loadConfig = async (cwd, entry) => {
 	const cwd = process.cwd();
 	const entry = args._.length > 0 ? path.join(cwd, args._[0]) : cwd;
 
-	const config = await loadConfig(cwd, entry);
+	const config = await loadConfig(cwd, entry, args);
 
 	if (args['--single']) {
 		const {rewrites} = config;

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -54,8 +54,8 @@ const getHelp = () => chalk`
       {bold $} {cyan serve} --version
       {bold $} {cyan serve} [-l {underline listen_uri} [-l ...]] [{underline directory}]
 
-      By default, {cyan serve} will listen on {bold 0.0.0.0:3000} and serve the current working directory 
-      on that address.
+      By default, {cyan serve} will listen on {bold 0.0.0.0:3000} and serve the
+      current working directory on that address.
 
       Specifying a single {bold --listen} argument will overwrite the default, not supplement it.
 


### PR DESCRIPTION
Add `--config` for users to specify custom paths to their `serve.json` file. 

Below is an example of configuring `serve` to use `serve.json` residing in the `scripts` directory:
```
serve --config scripts/serve.json
```

This closes zeit/serve#401.