### PR TITLE
Bump `serve-handler` to 5.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "boxen": "1.3.0",
     "chalk": "2.4.1",
     "clipboardy": "1.2.3",
-    "serve-handler": "5.0.3",
+    "serve-handler": "5.0.5",
     "update-check": "1.5.2"
   }
 }


### PR DESCRIPTION
Flows the Windows fixes from https://github.com/zeit/serve-handler/issues/59 through to `serve`. 