### PR TITLE
Deprecate support for `now.json` and `package.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now you understand how the package works! :tada:
 
 ## Configuration
 
-To customize `serve`'s behavior, create a `serve.json` file and insert any of [these properties](https://github.com/zeit/serve-handler#options). In addition, `serve` will also detect `now.json` files if they contain the `static` property.
+To customize `serve`'s behavior, create a `serve.json` file and insert any of [these properties](https://github.com/zeit/serve-handler#options).
 
 ## API
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -284,6 +284,10 @@ const loadConfig = async (cwd, entry, args) => {
 		Object.assign(config, content);
 		console.log(info(`Discovered configuration in \`${file}\``));
 
+		if (file === 'now.json' || file === 'package.json') {
+			console.error(warning('The config files `now.json` and `package.json` are deprecated. Please use `serve.json`.'));
+		}
+
 		break;
 	}
 


### PR DESCRIPTION
Since [Now 2.0](https://zeit.co/blog/now-2), there's no more support for `static` in any of the config files.