### PR TITLE
Missing option --no-compression in help message

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -81,7 +81,9 @@ const getHelp = () => chalk`
 
       -c, --config                        Specify custom path to \`serve.json\`
 
-      -n, --no-clipboard                  Do not copy the local address to the clipboard
+	  -n, --no-clipboard                  Do not copy the local address to the clipboard
+	  
+      -u, --no-compression                Do not compress files
 
       -S, --symlinks                      Resolve symlinks instead of showing 404 errors
 

--- a/bin/serve.js
+++ b/bin/serve.js
@@ -81,7 +81,7 @@ const getHelp = () => chalk`
 
       -c, --config                        Specify custom path to \`serve.json\`
 
-	  -n, --no-clipboard                  Do not copy the local address to the clipboard
+      -n, --no-clipboard                  Do not copy the local address to the clipboard
 	  
       -u, --no-compression                Do not compress files
 


### PR DESCRIPTION
Hi
I'm couldn't find any info on how to disable compression in the --help message.
But this feature actually exists. I found it in the source code.

These changes are adding a missed --no-compression option in the help message.