### PR TITLE
use path.resolve instead of path.join for config

### DIFF
--- a/bin/serve.js
+++ b/bin/serve.js
@@ -260,7 +260,7 @@ const loadConfig = async (cwd, entry, args) => {
 	const config = {};
 
 	for (const file of files) {
-		const location = path.join(entry, file);
+		const location = path.resolve(entry, file);
 		let content = null;
 
 		try {
@@ -311,7 +311,7 @@ const loadConfig = async (cwd, entry, args) => {
 
 	if (entry) {
 		const {public} = config;
-		config.public = path.relative(cwd, (public ? path.join(entry, public) : entry));
+		config.public = path.relative(cwd, (public ? path.resolve(entry, public) : entry));
 	}
 
 	if (Object.keys(config).length !== 0) {


### PR DESCRIPTION
This PR switches the config loading to use `path.resolve` instead of `path.join`. Presently, it only allows relative paths, but with this change, it works with both relative and absolute paths. In my particular case, I wanted to use `~/config.json`.

Incidentally, this also fixes #498