### PR TITLE
Fixed ZEIT Now reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 Assuming you would like to serve a static site, single page application or just a static file (no matter if on your device or on the local network), this package is just the right choice for you.
 
-It behaves exactly like static deployments on [Now](https://zeit.co/now), so it's perfect for developing your static project. Then, when it's time to push it into production, you [deploy it](https://zeit.co/docs/v2/introduction/).
+Once it's time to push your site to production, we recommend using [ZEIT Now](https://zeit.co/now).
 
-Furthermore, it provides a neat interface for listing the directory's contents:
+In general, `serve` also provides a neat interface for listing the directory's contents:
 
 ![screenshot](https://user-images.githubusercontent.com/6170607/40541195-167ff460-601b-11e8-8f66-3b0c7ff96cbb.png)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Assuming you would like to serve a static site, single page application or just a static file (no matter if on your device or on the local network), this package is just the right choice for you.
 
-It behaves exactly like static deployments on [Now](https://zeit.co/now), so it's perfect for developing your static project. Then, when it's time to push it into production, you [deploy it](https://zeit.co/docs/examples/static).
+It behaves exactly like static deployments on [Now](https://zeit.co/now), so it's perfect for developing your static project. Then, when it's time to push it into production, you [deploy it](https://zeit.co/docs/v2/introduction/).
 
 Furthermore, it provides a neat interface for listing the directory's contents:
 


### PR DESCRIPTION
- Update outdated link URL to the latest Now documentation.