### PR TITLE
fix: Non-breaking dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "arg": "5.0.2",
     "boxen": "7.1.1",
     "chalk": "5.3.0",
-    "chalk-template": "0.4.0",
+    "chalk-template": "1.1.0",
     "clipboardy": "3.0.0",
     "compression": "1.7.4",
     "is-port-reachable": "4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   boxen: 7.1.1
   c8: 7.12.0
   chalk: 5.3.0
-  chalk-template: 0.4.0
+  chalk-template: 1.1.0
   clipboardy: 3.0.0
   compression: 1.7.4
   eslint: 8.19.0
@@ -32,7 +32,7 @@ dependencies:
   arg: 5.0.2
   boxen: 7.1.1
   chalk: 5.3.0
-  chalk-template: 0.4.0
+  chalk-template: 1.1.0
   clipboardy: 3.0.0
   compression: 1.7.4
   is-port-reachable: 4.0.0
@@ -887,6 +887,7 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       color-convert: 2.0.1
+    dev: true
 
   /ansi-styles/6.1.0:
     resolution:
@@ -1212,14 +1213,14 @@ packages:
       type-detect: 4.0.8
     dev: true
 
-  /chalk-template/0.4.0:
+  /chalk-template/1.1.0:
     resolution:
       {
-        integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==,
+        integrity: sha512-T2VJbcDuZQ0Tb2EWwSotMPJjgpy1/tGee1BTpUNsGZ/qgNjV2t7Mvu+d4600U564nbLesN1x2dPL+xii174Ekg==,
       }
-    engines: { node: '>=12' }
+    engines: { node: '>=14.16' }
     dependencies:
-      chalk: 4.1.2
+      chalk: 5.3.0
     dev: false
 
   /chalk/2.4.1:
@@ -1243,6 +1244,7 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+    dev: true
 
   /chalk/5.3.0:
     resolution:
@@ -1391,6 +1393,7 @@ packages:
     engines: { node: '>=7.0.0' }
     dependencies:
       color-name: 1.1.4
+    dev: true
 
   /color-name/1.1.3:
     resolution:
@@ -1404,6 +1407,7 @@ packages:
       {
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
+    dev: true
 
   /colorette/2.0.19:
     resolution:
@@ -2871,6 +2875,7 @@ packages:
         integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
       }
     engines: { node: '>=8' }
+    dev: true
 
   /has-property-descriptors/1.0.0:
     resolution:
@@ -4945,6 +4950,7 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       has-flag: 4.0.0
+    dev: true
 
   /supports-preserve-symlinks-flag/1.0.0:
     resolution:


### PR DESCRIPTION
Performs the following dependency updates:

- Update `@zeit/schemas` from 2.29. to 2.35.0
- Update `boxen` from 7.0.0 to 7.1.1
- Update `chalk` from 5.0.1 to 5.3.0
- Update `chalk-template` from 0.4.0 to 1.1.0
  - Breaking changes since 0.4.0 are not an issue for this package:
    - Drop support for Node.js v12 (`serve` already requires minimum Node.js v14)
    - Upgrade chalk from v4 to v5 (For any compatibility concerns, `serve` is already on v5)
- ~Update `ajv` from 8.11.0 to 8.12.0~
  - ~This is also broken out separately in #796 - can be merge separately or as part of this PR.~

Maintainers: Let me know if you prefer this structured differently!

#### Related
- Updating `clipboardy` depends on dropping Node.js v14-v16 support: #793 