### PR TITLE
test(server): return 404 for unknown routes

### DIFF
--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -85,8 +85,16 @@ describe('utilities/server', () => {
     );
   });
 
+  // Verify server returns 404 for unknown routes
+  test('server responds with 404 for unknown routes',async()=>{
+    const serverInstance=await startServer({port:3005},config,{});
+    const response=await fetch(`${serverInstance.local}/unknown`);
+    expect(response.status).toBe(404);
+    })
+  })
+
   // Make sure the server logs requests by default.
-  test('log requests to the server by default', async () => {
+  test('do not log requests when request logging is disabled', async () => {
     const consoleSpy = vi.spyOn(logger, 'http');
     const address = await startServer({ port: 3004 }, config, {
       '--no-request-logging': true,


### PR DESCRIPTION
## What does this PR do?

This PR adds a unit test to ensure the server correctly responds with a `404` status code when an unknown route is requested.

## Why is this needed?

Handling unknown routes explicitly is an important part of predictable server behavior.
This test improves coverage and helps prevent regressions where undefined routes might return incorrect responses.

## Changes made
- Added a new test case that starts the server
- Sends a request to an unknown endpoint
- Asserts that the response status is `404`

## Testing
- Tests can be run locally using `pnpm test`
