### PR TITLE
fix(deps): use caret version range for production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,17 +38,17 @@
     "release": "pnpm compile && changeset publish"
   },
   "dependencies": {
-    "@zeit/schemas": "2.36.0",
-    "ajv": "8.18.0",
-    "arg": "5.0.2",
-    "boxen": "7.0.0",
-    "chalk": "5.0.1",
-    "chalk-template": "0.4.0",
-    "clipboardy": "3.0.0",
-    "compression": "1.8.1",
-    "is-port-reachable": "4.0.0",
-    "serve-handler": "6.1.7",
-    "update-check": "1.5.4"
+    "@zeit/schemas": "^2.36.0",
+    "ajv": "^8.18.0",
+    "arg": "^5.0.2",
+    "boxen": "^7.0.0",
+    "chalk": "^5.0.1",
+    "chalk-template": "^0.4.0",
+    "clipboardy": "^3.0.0",
+    "compression": "^1.8.1",
+    "is-port-reachable": "^4.0.0",
+    "serve-handler": "^6.1.7",
+    "update-check": "^1.5.4"
   },
   "devDependencies": {
     "@changesets/cli": "2.29.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,37 +8,37 @@ importers:
   .:
     dependencies:
       '@zeit/schemas':
-        specifier: 2.36.0
+        specifier: ^2.36.0
         version: 2.36.0
       ajv:
-        specifier: 8.18.0
+        specifier: ^8.18.0
         version: 8.18.0
       arg:
-        specifier: 5.0.2
+        specifier: ^5.0.2
         version: 5.0.2
       boxen:
-        specifier: 7.0.0
+        specifier: ^7.0.0
         version: 7.0.0
       chalk:
-        specifier: 5.0.1
+        specifier: ^5.0.1
         version: 5.0.1
       chalk-template:
-        specifier: 0.4.0
+        specifier: ^0.4.0
         version: 0.4.0
       clipboardy:
-        specifier: 3.0.0
+        specifier: ^3.0.0
         version: 3.0.0
       compression:
-        specifier: 1.8.1
+        specifier: ^1.8.1
         version: 1.8.1
       is-port-reachable:
-        specifier: 4.0.0
+        specifier: ^4.0.0
         version: 4.0.0
       serve-handler:
-        specifier: 6.1.7
+        specifier: ^6.1.7
         version: 6.1.7
       update-check:
-        specifier: 1.5.4
+        specifier: ^1.5.4
         version: 1.5.4
     devDependencies:
       '@changesets/cli':


### PR DESCRIPTION
Should ease maintenance by allowing dependents to update this project's dependencies to non-breaking, more up-to-date versions.

Same as https://github.com/vercel/serve-handler/pull/229, cc @AndyBitz.