### PR TITLE
fix(config): allow null values in header rules

### DIFF
--- a/source/utilities/config.ts
+++ b/source/utilities/config.ts
@@ -14,6 +14,42 @@ import { logger } from './logger.js';
 import type { ErrorObject } from 'ajv';
 import type { Configuration, Options, NodeError } from '../types.js';
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const schemaWithNullableHeaderValue = (() => {
+  const staticSchema = JSON.parse(JSON.stringify(schema)) as Record<
+    string,
+    unknown
+  >;
+  const properties = staticSchema.properties;
+  if (!isRecord(properties)) return staticSchema;
+
+  const headers = properties.headers;
+  if (!isRecord(headers)) return staticSchema;
+
+  const headerItems = headers.items;
+  if (!isRecord(headerItems)) return staticSchema;
+
+  const headerProperties = headerItems.properties;
+  if (!isRecord(headerProperties)) return staticSchema;
+
+  const headerEntries = headerProperties.headers;
+  if (!isRecord(headerEntries)) return staticSchema;
+
+  const headerEntryItems = headerEntries.items;
+  if (!isRecord(headerEntryItems)) return staticSchema;
+
+  const headerEntryProperties = headerEntryItems.properties;
+  if (!isRecord(headerEntryProperties)) return staticSchema;
+
+  const headerValue = headerEntryProperties.value;
+  if (!isRecord(headerValue)) return staticSchema;
+
+  headerValue.type = ['string', 'null'];
+  return staticSchema;
+})();
+
 /**
  * Parses and returns a configuration object from the designated locations.
  *
@@ -122,7 +158,7 @@ export const loadConfiguration = async (
   // If the configuration isn't empty, validate it against the AJV schema.
   if (Object.keys(config).length !== 0) {
     const ajv = new Ajv({ allowUnionTypes: true });
-    const validate = ajv.compile(schema as object);
+    const validate = ajv.compile(schemaWithNullableHeaderValue as object);
 
     if (!validate(config) && validate.errors) {
       const defaultMessage = 'The configuration you provided is invalid:';

--- a/tests/__fixtures__/config/header-removal/serve.json
+++ b/tests/__fixtures__/config/header-removal/serve.json
@@ -1,0 +1,23 @@
+{
+  "public": "app/",
+  "headers": [
+    {
+      "source": "**",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "max-age=86400"
+        }
+      ]
+    },
+    {
+      "source": "service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": null
+        }
+      ]
+    }
+  ]
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,7 +11,7 @@ import { Options } from '../source/types.js';
 const fixtures = 'tests/__fixtures__/config/';
 // A helper function to load the configuration for a certain fixture.
 const loadConfig = (
-  name: 'valid' | 'invalid' | 'non-existent' | 'deprecated',
+  name: 'valid' | 'invalid' | 'non-existent' | 'deprecated' | 'header-removal',
   args?: Partial<Options> = {},
 ) => loadConfiguration(process.cwd(), `${fixtures}/${name}`, args);
 
@@ -64,5 +64,22 @@ describe('utilities/config', () => {
     expect(consoleSpy).toHaveBeenLastCalledWith(
       expect.stringContaining('deprecated'),
     );
+  });
+
+  // `serve-handler` supports `null` to remove previously defined headers.
+  // This should pass config validation as well.
+  test('accept null header values for header removal rules', async () => {
+    const configuration = await loadConfig('header-removal');
+
+    expect(configuration.headers).toEqual([
+      {
+        source: '**',
+        headers: [{ key: 'Cache-Control', value: 'max-age=86400' }],
+      },
+      {
+        source: 'service-worker.js',
+        headers: [{ key: 'Cache-Control', value: null }],
+      },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- allow  to be  during  schema validation
- add a config fixture and regression test that loads header-removal rules

## Why
 supports using  to remove a previously defined header value, but  rejected such config values before passing config through.

Fixes #438.

## Testing
- 
> serve@14.2.6 test:tsc /Users/h1syu1/PythonProjects/prs2-serve/serve
> tsc --project tsconfig.json
- 
 RUN  v2.1.3 /Users/h1syu1/PythonProjects/prs2-serve/serve
      Coverage enabled with v8

 ✓ tests/config.test.ts  (6 tests) 43ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  03:26:55
   Duration  493ms (transform 23ms, setup 0ms, collect 46ms, tests 43ms, environment 0ms, prepare 40ms)

 % Coverage report from v8
------------------|---------|----------|---------|---------|--------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s  
------------------|---------|----------|---------|---------|--------------------
All files         |    9.72 |    51.21 |   35.71 |    9.72 |                    
 build            |       0 |        0 |       0 |       0 |                    
  main.js         |       0 |        0 |       0 |       0 | 1-606              
 config           |       0 |        0 |       0 |       0 |                    
  vitest.ts       |       0 |        0 |       0 |       0 | 1-16               
 source           |       0 |       50 |      50 |       0 |                    
  main.ts         |       0 |        0 |       0 |       0 | 1-163              
  types.ts        |       0 |        0 |       0 |       0 |                    
 source/utilities |   30.56 |    54.05 |      40 |   30.56 |                    
  cli.ts          |       0 |        0 |       0 |       0 | 1-207              
  config.ts       |   88.54 |    54.83 |     100 |   88.54 | ...116-121,125-126 
  http.ts         |       0 |        0 |       0 |       0 | 1-43               
  logger.ts       |   72.72 |      100 |      25 |   72.72 | 9,11,15            
  promise.ts      |     100 |      100 |     100 |     100 |                    
  server.ts       |       0 |        0 |       0 |       0 | 1-206              
------------------|---------|----------|---------|---------|--------------------